### PR TITLE
Embed vimeo into sine waves page, and other tidying

### DIFF
--- a/sine_waves.html
+++ b/sine_waves.html
@@ -53,142 +53,119 @@ Any sine wave can be described by three numbers: its amplitude (the height of th
 </p>
 
 <h2>
-Prof. Wood's Overview Videos:
+Prof. Wood's Overview Videos
 </h2>
 
-<p>
-Intro to Sine Waves:
-</p>
-
-<p>
+<h3>
 The function, graph, amplitude and period of a sine wave.
-</p>
+</h3>
 
-<p>
-    <a href="https://vimeo.com/354282529">https://vimeo.com/354282529</a>
-</p>
+<iframe src="https://player.vimeo.com/video/354282529?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
 
-<p>
-Angular Frequency:
-</p>
+<h3>
+Angular Frequency
+</h3>
 
 <p>
 What angular frequency and frequency are, how they are related and their units of measure.
 </p>
 
-<p>
-<a href="https://vimeo.com/354283781">https://vimeo.com/354283781</a>
-</p>
+<iframe src="https://player.vimeo.com/video/354283781?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
 
-<p>
-Frequency and Period:
-</p>
+
+<h3>
+Frequency and Period
+</h3>
 
 <p>
 Relationship between frequency and period, how adjusting one affects the other.
 </p>
 
-<p>
-<a href="https://vimeo.com/354284308">https://vimeo.com/354284308</a>
-</p>
-<p>
-Changing Amplitude:
-</p>
+<iframe src="https://player.vimeo.com/video/354284308?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+
+<h3>
+Changing Amplitude
+</h3>
 
 <p>
 Effect of changing amplitude on a sine wave graph and how changing the amplitude of a sound wave affects human perception.
 </p>
 
-<p>
-<a href="https://vimeo.com/354284403">https://vimeo.com/354284403</a>
-</p>
+<iframe src="https://player.vimeo.com/video/354284403?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
 
-<p>
-Changing Angular Frequency:
-</p>
+<h3>
+Changing Angular Frequency
+</h3>
 
 <p>
 Effect of changing angular frequency on a sine wave graph and how the period changes as a result.
 </p>
 
-<p>
-<a href="https://vimeo.com/354284758">https://vimeo.com/354284758</a>
-</p>
+<iframe src="https://player.vimeo.com/video/354284758?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
 
-<p>
-Angular Frequency and Octaves:
-</p>
+<h3>
+Angular Frequency and Octaves
+</h3>
 
 <p>
 How the angular frequency of a sine wave relates to going up or down an octave in music.
 </p>
 
-<p>
-<a href="https://vimeo.com/354285144">https://vimeo.com/354285144</a>
-</p>
+<iframe src="https://player.vimeo.com/video/354285144?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
 
-<p>
-Representing Pitch Through Sine Waves:
-</p>
+<h3>
+Representing Pitch Through Sine Waves
+</h3>
 
 <p>
 How sine waves represent pitches and how pitches make up a note.
 </p>
 
-<p>
-<a href="https://vimeo.com/354285392">https://vimeo.com/354285392</a>
-</p>
+<iframe src="https://player.vimeo.com/video/354285392?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
 
-<p>
-Human Perception of Oscillations:
-</p>
+<h3>
+Human Perception of Oscillations
+</h3>
 
 <p>
 How we perceive oscillations as a single tone and the limits of human hearing in terms of angular frequency of a sine wave.
 </p>
-<p>
-<a href="https://vimeo.com/354285538">https://vimeo.com/354285538</a>
-</p>
 
-<p>
-Effect of Phase on a Sine Wave:
-</p>
+<iframe src="https://player.vimeo.com/video/354285538?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+
+<h3>
+Effect of Phase on a Sine Wave
+</h3>
 
 <p>
 Introduction to what phase is in a sine equation and example graph of how phase shifts the a sine graph horizontally.
 </p>
 
-<p>
-<a href="https://vimeo.com/354285967">https://vimeo.com/354285967</a>
-</p>
+<iframe src="https://player.vimeo.com/video/354285967?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
 
-<p>
-Combining Sine Waves:
-</p>
+<h3>
+Combining Sine Waves
+</h3>
 
 <p>
 Example of sine waves with different phases and how they combine constructively or destructively. Explanation of how phase is used to create noise cancelling headphones.
 </p>
 
-<p>
-<a href="https://vimeo.com/354286722">https://vimeo.com/354286722</a>
-</p>
+<iframe src="https://player.vimeo.com/video/354286722?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
 
-<p>
-Cosine in Terms of Sine:
-</p>
+<h3>
+Cosine in Terms of Sine
+</h3>
 
 <p>
 Definition of cosine in terms of sine at a certain phase.
 </p>
 
-<p>
-<a href="https://vimeo.com/354287037">https://vimeo.com/354287037</a>
-</p>
+<iframe src="https://player.vimeo.com/video/354287037?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
 
-<p>
-Some more resources:
-</p>
+<h3>
+More resources
+</h3>
 
 <ul>
 <li>Let’s learn about waveforms: <a href="https://pudding.cool/2018/02/waveforms/">https://pudding.cool/2018/02/waveforms/</a>


### PR DESCRIPTION
This PR embeds the Vimeo videos directly into the sine waves html file.

Along the way, some minor styling improvements are made: video titles are made `<h3>` and colons are removed.