### PR TITLE
Remove TODOs from README (add a link to issues)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,17 @@
-### Toolkit TODOs:
+# GenEd 1080 Toolkit
 
-Hosting
-- a menu? easy way to navigate between sections?
-- link from Canvas
-- styling?
+## Sitemap
 
-Content
-- index/welcome page: one-sentence overview descriptions of each item
-- math page: one-sentence overview descriptions of each item
-- music page: add videos, titles, short descriptions.
-- coding page: get new notebook installation vids from salma, host on vimeo.
-- coding page: increase volume on salma's individual notebook videos & host on LL Vimeo.
-- coding page: blurb for "what's a Jupityr Notebook"
-- coding page: one-sentence overview descriptions of each notebook video
-- sine waves page: “What are sine waves” blurb
-- sine waves page: format "more resources" and write descriptions
-- logarithms page: insert image in "What are logarithms"
-- logarithms page: embed videos
-- logarithms page: format "more resources" and write descriptions
-- complex numbers page: copy "What are complex numbers" from Google doc w/ LaTeX
-- complex numbers page: embed videos
-- complex numbers page: format "more resources" and write descriptions
-- deriv int page: "How do derivatives and integrals relate to music?" blurb.
-- deriv int page: add Integrals paragraph in the "What are derivatives and integrals?" blurb.
-- deriv int page: embed videos
-- deriv int page: reshoot "Definition of Integrals in Terms of dx" per Emmy's suggestions
-- deriv int page: format "more resources" and write descriptions
-- diff eqs page: write "How do differential equations relate to music?" blurb
-- diff eqs page: edit "What are differential equations" blurb (see google doc)
-- diff eqs page: embed videos
-- diff eqs page: format "more resources" and write descriptions
+- index.html  
+- math.html
+	- sine_waves.html
+	- logarithms.html
+	- complex_numbers.html
+	- derivatives_integrals.html
+	- diff_eqs.html
+- music.html
+- coding.html
 
-extras:
-- rob definition of derivatives reshoot
-- add visuals to videos emmy recommended
-- zachary: expand sin(x) inscribed triangle animation? draw the triangle the whole time, and two colors showing sine and cosine (label those)
-- Jim/Zachary: some errors in the logarithms observable? (exponents in “how do you use them in music”
+## TODOs
 
-### Sitemap:
-
-index.html  
-math.html  
-- sine_waves.html
-- logarithms.html
-- complex_numbers.html
-- derivatives_integrals.html
-- diff_eqs.html  
-music.html  
-coding.html  
+See the [issues page](https://github.com/davidforrest/1080-toolkit/issues) for work that still needs to be done!


### PR DESCRIPTION
This PR removes all of the TODOs from the `README.md` and replaces them with a link to the issues page where they are now tracked.