### PR TITLE
Use fonts to match Bok Center

### DIFF
--- a/1080-toolkit.css
+++ b/1080-toolkit.css
@@ -1,3 +1,19 @@
-* {
-	font-family: 'Open Sans', sans-serif;
+h1 {
+	font-family: 'Lato', sans-serif;
+}
+
+h2 {
+	font-family: 'Lato', sans-serif;
+}
+
+h3 {
+	font-family: 'Lato', sans-serif;
+}
+
+p {
+	font-family: 'Merriweather', serif;
+}
+
+li {
+	font-family: 'Merriweather', serif;
 }

--- a/coding.html
+++ b/coding.html
@@ -4,7 +4,8 @@
 
 <head>
   <link rel="stylesheet" href="1080-toolkit.css">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/complex_numbers.html
+++ b/complex_numbers.html
@@ -4,7 +4,8 @@
 
 <head>
   <link rel="stylesheet" href="1080-toolkit.css">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/derivatives_integrals.html
+++ b/derivatives_integrals.html
@@ -4,7 +4,8 @@
 
 <head>
   <link rel="stylesheet" href="1080-toolkit.css">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/diff_eqs.html
+++ b/diff_eqs.html
@@ -4,7 +4,8 @@
 
 <head>
   <link rel="stylesheet" href="1080-toolkit.css">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 
 <head>
   <link rel="stylesheet" href="1080-toolkit.css">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/logarithms.html
+++ b/logarithms.html
@@ -4,7 +4,8 @@
 
 <head>
   <link rel="stylesheet" href="1080-toolkit.css">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/math.html
+++ b/math.html
@@ -4,7 +4,8 @@
 
 <head>
   <link rel="stylesheet" href="1080-toolkit.css">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/music.html
+++ b/music.html
@@ -4,7 +4,8 @@
 
 <head>
   <link rel="stylesheet" href="1080-toolkit.css">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/sine_waves.html
+++ b/sine_waves.html
@@ -5,6 +5,7 @@
 <head>
   <link rel="stylesheet" href="1080-toolkit.css">
   <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/sine_waves.html
+++ b/sine_waves.html
@@ -4,7 +4,7 @@
 
 <head>
   <link rel="stylesheet" href="1080-toolkit.css">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
 </head>
 
 <body>


### PR DESCRIPTION
This PR introduces the Lato and Merriweather fonts used by the Box Center site.

These don't have to be the final choice, but they could create some consistency, if such a thing is desired.