### PR TITLE
Add first-order menu and header

### DIFF
--- a/1080-toolkit.css
+++ b/1080-toolkit.css
@@ -4,6 +4,57 @@
   -moz-box-sizing: border-box;
 }
 
+#header {
+  background-color: teal;
+  height: 100px;
+}
+
+#header h2 {
+  line-height: 100px;
+  text-align: left;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-left: 200px;
+  color: white;
+}
+
+#menu-container {
+  text-align: left;
+}
+
+.menu {
+  list-style-type: none;
+  background-color: #AF263F;
+  margin-top: 0px;
+  padding-left: 200px;
+}
+
+.menu ul {
+  list-style-type: none;
+}
+
+.menu li {
+  display: inline;
+  font-family: 'Lato', serif;
+  font-size: 17.1px;
+  font-weight: bold;
+  padding-right: 24px;
+  letter-spacing: .8px;
+  text-transform: uppercase;
+  color: #CCCCCC;
+}
+
+.menu a {
+  text-decoration: none;
+  display: inline;
+  font-family: 'Lato', serif;
+  font-size: 17.1px;
+  font-weight: bold;
+  letter-spacing: .8px;
+  text-transform: uppercase;
+  color: white;
+}
+
 #content-column {
   margin-left: 200px;
   margin-right: 200px;
@@ -62,7 +113,7 @@ h1 {
   margin: 55px 0px;
   text-transform: uppercase;
   letter-spacing: -1px;
-  color: crimson;
+  color: teal;
 }
 
 h2 {
@@ -92,6 +143,7 @@ p {
 li {
   font-family: 'Merriweather', serif;
   line-height: 30px;
+  margin: ;
 }
 
 .video-container {

--- a/coding.html
+++ b/coding.html
@@ -2,10 +2,24 @@
 <html>
   <head>
     <link rel="stylesheet" href="1080-toolkit.css">
-    <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Lato:300,400&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
   </head>
   <body>
+
+    <div id="header">
+      <h2>GENED 1080 TOOLKIT</h1>  
+    </div>
+    
+    <div id="menu-container">
+      <ul class="menu">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="math.html">Math</a></li>
+        <li><a href="music.html">Music</a></li>
+        <li>Coding</li>
+      </ul>
+    </div>
+
     <div id="content-column">
       <h1>Coding</h1>
       <h2>Welcome to the GE1080 Coding Toolkit!</h2>

--- a/complex_numbers.html
+++ b/complex_numbers.html
@@ -6,6 +6,20 @@
     <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
   </head>
   <body>
+
+    <div id="header">
+      <h2>GENED 1080 TOOLKIT</h1>  
+    </div>
+    
+    <div id="menu-container">
+      <ul class="menu">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="math.html">Math</a></li>
+        <li><a href="music.html">Music</a></li>
+        <li><a href="coding.html">Coding</a></li>
+      </ul>
+    </div>
+
     <div id="content-column">
       <h1>Complex Numbers</h1>
       <div class="q-a-container">

--- a/derivatives_integrals.html
+++ b/derivatives_integrals.html
@@ -6,6 +6,20 @@
     <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
   </head>
   <body>
+
+    <div id="header">
+      <h2>GENED 1080 TOOLKIT</h1>  
+    </div>
+    
+    <div id="menu-container">
+      <ul class="menu">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="math.html">Math</a></li>
+        <li><a href="music.html">Music</a></li>
+        <li><a href="coding.html">Coding</a></li>
+      </ul>
+    </div>
+
     <div id="content-column">
       <h1>Derivatives and Integrals</h1>
 

--- a/diff_eqs.html
+++ b/diff_eqs.html
@@ -6,6 +6,20 @@
     <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
   </head>
   <body>
+
+  	<div id="header">
+      <h2>GENED 1080 TOOLKIT</h1>  
+    </div>
+    
+    <div id="menu-container">
+      <ul class="menu">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="math.html">Math</a></li>
+        <li><a href="music.html">Music</a></li>
+        <li><a href="coding.html">Coding</a></li>
+      </ul>
+    </div>
+  	
     <div id="content-column">
       <h1>Differential Equations</h1>
       <div class="q-a-container">

--- a/index.html
+++ b/index.html
@@ -6,8 +6,22 @@
     <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
   </head>
   <body>
+
+    <div id="header">
+      <h2>GENED 1080 TOOLKIT</h1>  
+    </div>
+    
+    <div id="menu-container">
+      <ul class="menu">
+        <li>Home</li>
+        <li><a href="math.html">Math</a></li>
+        <li><a href="music.html">Music</a></li>
+        <li><a href="coding.html">Coding</a></li>
+      </ul>
+    </div>
+
     <div id="content-column">
-      <h1>GENED 1080 TOOLKIT</h1>
+      
       <div id="toolkit-overview">
         <p>
         The GenEd 1080 Toolkit is a collection of resources you can draw from throughout the semester to brush up/level up on your math, music, and coding skills. It’s full of links to helpful videos, explorable web apps, and interesting tangents related to topics in the course.

--- a/logarithms.html
+++ b/logarithms.html
@@ -7,6 +7,20 @@
   </head>
 
   <body>
+
+    <div id="header">
+      <h2>GENED 1080 TOOLKIT</h1>  
+    </div>
+    
+    <div id="menu-container">
+      <ul class="menu">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="math.html">Math</a></li>
+        <li><a href="music.html">Music</a></li>
+        <li><a href="coding.html">Coding</a></li>
+      </ul>
+    </div>
+
     <div id="content-column">
       <h1>Logarithms</h1>
       <div class="q-a-container">

--- a/math.html
+++ b/math.html
@@ -2,10 +2,24 @@
 <html>
   <head>
     <link rel="stylesheet" href="1080-toolkit.css">
-    <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Lato:300,400&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
   </head>
   <body>
+
+    <div id="header">
+      <h2>GENED 1080 TOOLKIT</h1>  
+    </div>
+    
+    <div id="menu-container">
+      <ul class="menu">
+        <li><a href="index.html">Home</li>
+        <li>Math</li>
+        <li><a href="music.html">Music</a></li>
+        <li><a href="coding.html">Coding</a></li>
+      </ul>
+    </div>
+
     <div id="content-column">
       <h1>Math</h1>   
       <h2>Welcome to the GE1080 Math Toolkit!</h2>

--- a/music.html
+++ b/music.html
@@ -2,25 +2,40 @@
 <html>
   <head>
     <link rel="stylesheet" href="1080-toolkit.css">
-    <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Lato:300,400&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
   </head>
   <body>
-  <div id="content-column">
-    <h1>Music</h1>
-    <h2>Welcome to the GE1080 Music Toolkit!</h2>
-    <p>
-    The <strong>Music Toolkit</strong> introduces the physics and math behind musical scales, and covers some basic theory that will help you write a chart-topping hit.
-    </p>
-    <div class="section-overview">
-      <ul>
-        <li>Constructing a Musical System
-        <li>The Tonal Center
-        <li>Degrees and Intervals
-        <li>Chords and Triads
-        <li>Rhythm and Meter
+
+    <div id="header">
+      <h2>GENED 1080 TOOLKIT</h1>  
+    </div>
+    
+    <div id="menu-container">
+      <ul class="menu">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="math.html">Math</a></li>
+        <li>Music</li>
+        <li><a href="coding.html">Coding</a></li>
       </ul>
     </div>
-  </div>
+
+    <div id="content-column">
+      <h1>Music</h1>
+      <h2>Welcome to the GE1080 Music Toolkit!</h2>
+      <p>
+      The <strong>Music Toolkit</strong> introduces the physics and math behind musical scales, and covers some basic theory that will help you write a chart-topping hit.
+      </p>
+      <div class="section-overview">
+        <ul>
+          <li>Constructing a Musical System
+          <li>The Tonal Center
+          <li>Degrees and Intervals
+          <li>Chords and Triads
+          <li>Rhythm and Meter
+        </ul>
+      </div>
+    </div>
+
   </body>
 </html>

--- a/sine_waves.html
+++ b/sine_waves.html
@@ -6,6 +6,20 @@
     <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
   </head>
   <body>
+
+  	<div id="header">
+      <h2>GENED 1080 TOOLKIT</h1>  
+    </div>
+    
+    <div id="menu-container">
+      <ul class="menu">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="math.html">Math</a></li>
+        <li><a href="music.html">Music</a></li>
+        <li><a href="coding.html">Coding</a></li>
+      </ul>
+    </div>
+
     <div id="content-column">
       <h1>Sine Waves</h1>
       <div class="q-a-container">


### PR DESCRIPTION
This PR adds a primitive menu to all pages. This menu allows you to navigate to any of the top level pages (`Home`, `Math`, `Music`, and `Coding`).

Further work will be to add a hover-over sub-menu for the `Math` menu item (à la Learning Lab site).