### PR TITLE
Add LaTeX notation to complex numbers page

### DIFF
--- a/complex_numbers.html
+++ b/complex_numbers.html
@@ -4,6 +4,14 @@
     <link rel="stylesheet" href="1080-toolkit.css">
     <link href="https://fonts.googleapis.com/css?family=Lato:300,400&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
+    <script type="text/javascript" async
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML">
+    </script>
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+        tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+      });
+    </script>
   </head>
   <body>
 
@@ -33,20 +41,27 @@
 
         <h2 class="question">What are complex numbers?</h2>
         <p>
-          Complex numbers are a number system where the square root of -1 is declared to be a valid number. For example, the number 4 has two square roots: 2 and -2. But what number would you square to get -4? This is where the square root of -1 (usually called <em><strong>i</strong></em> for “imaginary”) comes to the rescue:
+          Complex numbers are a number system where the square root of $-1$ is declared to be a valid number. For example, the number $4$ has two square roots: $2$ and $-2$. But what number would you square to get $-4$? This is where the square root of $-1$ (usually called $i$ for “imaginary”) comes to the rescue.
         </p>
 
-        <p class="todo">INSERT LaTeX NOTATION HERE</p>
+        <p>$i = \sqrt{-1}$</p>
 
         <p>
-        A complex number can be expressed in terms of two components - a real part and an imaginary part. The real part is what we’re all used to when we think of numbers: like 1, 3, 5, 𝞹, and so forth. The imaginary part is a real number multiplied by <em>i</em>.
+        A complex number can be expressed in terms of two components: a real part and an imaginary part. The real part is what we’re all used to when we think of numbers: like $1$, $3$, $5$, $\pi$, and so forth. The imaginary part is a real number multiplied by $i$.
         </p>
 
         <p>
-        Complex numbers are usually graphed on the “complex plane”. You may be familiar with the number line, a one-dimensional line that describes all real numbers, with zero in the middle, positive numbers on the right and negatives on the left. the complex plane is a two-dimensional plane, where zero is still in the middle, positives on the right, and negatives on the left, but this time multiples of <em>i</em> go <em>upwards</em> from zero, and multiples of negative <em>i</em> go downwards from zero. So to graph a number a+b<em>i</em>, you’d go right or left depending on the value of a, then go up or down depending on the value of b.
+        Complex numbers are usually graphed on the “complex plane”. You may be familiar with the number line, a one-dimensional line that describes all real numbers, with zero in the middle, positive numbers on the right and negatives on the left. the complex plane is a two-dimensional plane, where zero is still in the middle, positives on the right, and negatives on the left, but this time multiples of $i$ go <em>upwards</em> from zero, and multiples of negative $i$ go downwards from zero. So to graph a number $a+bi$, you’d go right or left depending on the value of $a$, then go up or down depending on the value of 
+        $b$.
         </p>
 
-        <p class="todo">COPY TEXT FROM GOOGLE DOC USING LaTeX</p>
+        <p>
+        The following are examples of complex numbers: $1+2i$, $1.56+10i$. All real numbers can also be represented as complex numbers by having a zero imaginary part: $2+0i$, $-100+0i$, and so on.
+        </p>
+
+        <p>
+        So multiplication, an abstract, algebraic thing to do, is transformed into rotating and scaling, a visual, geometric thing to do. That’s the beauty of complex numbers!
+        </p>
 
       </div>
 
@@ -57,15 +72,15 @@
       <div class="video-container">
         <div class="video-description">
           <h3 class="video-title">Complex Numbers and Number Sets</h3>
-          <p>Definition of a complex number as a number set. Break down of the real, imaginary and “i” components of a complex number.</p>
+          <p>Definition of a complex number as a number set. Break down of the real, imaginary and $i$ components of a complex number.</p>
         </div>
         <iframe style="float:right" src="https://player.vimeo.com/video/354265137?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
       </div>
 
       <div class="video-container">
         <div class="video-description">
-          <h3 class="video-title">Definition of <i>i</i></h3>
-          <p>Definition of <i>i</i> in a complex number and its properties in terms of raising it to a power.</p>
+          <h3 class="video-title">Definition of $i$</h3>
+          <p>Definition of $i$ in a complex number and its properties in terms of raising it to a power.</p>
         </div>
         <iframe style="float:right" src="https://player.vimeo.com/video/354265768?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
       </div>


### PR DESCRIPTION
This PR asks for `MathJax` to be loaded via CDN for the complex numbers page. All number-y things are converted to a `LaTeX` notation, which is parsed and rendered (quite beautifully) by `MathJax`.

